### PR TITLE
Small script fixes

### DIFF
--- a/bin/bash/metanovo.sh
+++ b/bin/bash/metanovo.sh
@@ -24,7 +24,7 @@ if [ ! -d "$mgf_folder" ]; then
 fi
 
 fasta_file=${FASTA_FILE}
-if [ ! -d "$fasta_file" ]; then
+if [ ! -f "$fasta_file" ]; then
       echo $fasta_file does not exist; exit 1
 fi
 
@@ -38,7 +38,7 @@ echo ${mgf_folder}
 echo ${fasta_file}
 echo ${output_folder}
 mkdir ${output_folder}/temp
-export $TMPDIR=${output_folder}/temp
+export TMPDIR=${output_folder}/temp
 
 # set the TMPDIR to outputfolder...SQLITE crashes on ilifu..TO DO
 


### PR DESCRIPTION
This addresses a couple of items needed to run `bin/bash/metanovo.sh`:
- Use `-f` instead of `-d` for the FASTA file, since it is not expected to be a directory. Although it looks like this variable is not actually used by this script, where instead the second command-line argument is used for the input FASTA file, I kept the check in case it was intended to ensure the variable was set for other parts of the codebase.
- Fix syntax when setting `TMPDIR`.

I'm submitting these changes are part of an effort to create a bioconda recipe for MetaNovo. 